### PR TITLE
Making download source configurable, to allow for optional optimization.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,6 @@
 # accepted values are 'search_api_solr' or 'apachesolr'
 drupal_solr_package: "search_api_solr"
 default_collection_name: "vlad"
+# See https://www.apache.org/dyn/closer.cgi/lucene/solr/ for a list of
+# available mirrors.
+default_solr_source: "http://www.mirrorservice.org/sites/ftp.apache.org/lucene/solr/"

--- a/tasks/debian_solr.yml
+++ b/tasks/debian_solr.yml
@@ -1,6 +1,6 @@
 ---
 - name: download Solr
-  command: wget http://www.mirrorservice.org/sites/ftp.apache.org/lucene/solr/4.10.4/solr-4.10.4.tgz chdir=/home/{{ user }} creates=/home/{{ user }}/solr-4.10.4.tgz
+  command: wget {{ default_solr_source }}4.10.4/solr-4.10.4.tgz chdir=/home/{{ user }} creates=/home/{{ user }}/solr-4.10.4.tgz
 
 - name: extract Solr
   command: tar -zxf /home/{{ user }}/solr-4.10.4.tgz chdir=/home/{{ user }} creates=/home/{{ user }}/solr-4.10.4

--- a/tasks/redhat_solr.yml
+++ b/tasks/redhat_solr.yml
@@ -1,6 +1,6 @@
 ---
 - name: download Solr
-  command: wget http://www.mirrorservice.org/sites/ftp.apache.org/lucene/solr/4.7.2/solr-4.7.2.tgz chdir=/home/{{ user }} creates=/home/{{ user }}/solr-4.7.2.tgz
+  command: wget {{ default_solr_source }}4.7.2/solr-4.7.2.tgz chdir=/home/{{ user }} creates=/home/{{ user }}/solr-4.7.2.tgz
 
 - name: extract Solr
   command: tar -zxf /home/{{ user }}/solr-4.7.2.tgz chdir=/home/{{ user }} creates=/home/{{ user }}/solr-4.7.2


### PR DESCRIPTION
I've been looking into ways to optimize the VLAD build time. One of the areas I noticed that was taking up a lot of time was the "download Solr" step. I tested various [solr mirrors](https://www.apache.org/dyn/closer.cgi/lucene/solr/) and found that I could consistently download the file in under a minute from some mirrors, but the same step using www.mirrorservice.org, which was hard coded in this role, was taking anywhere from 2-11 minutes.

This patch keeps the default behavior the same, but adds a variable to allow for the download point to be overridden from the vlad_settings.yml file.
